### PR TITLE
remove failed package id from csproj files

### DIFF
--- a/BitwardenJsonConverter/Source/Base.Contract/Base.Contract.csproj
+++ b/BitwardenJsonConverter/Source/Base.Contract/Base.Contract.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <AssemblyName>KaWoDev.BitwardenJsonConverter.Base.Contract</AssemblyName>
     <RootNamespace>KaWoDev.BitwardenJsonConverter.Base.Contract</RootNamespace>
-    <PackageId>KaWoDev.BitwardenJsonConverter.</PackageId>
     <Authors>KaWoDev &amp; Github Contributers</Authors>
     <PackageProjectUrl>https://github.com/kawodev/bitwardenJsonConverter</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/kawodev/bitwardenJsonConverter/License</PackageLicenseUrl>

--- a/BitwardenJsonConverter/Source/BitwardenConverter.Contract/BitwardenConverter.Contract.csproj
+++ b/BitwardenJsonConverter/Source/BitwardenConverter.Contract/BitwardenConverter.Contract.csproj
@@ -6,7 +6,6 @@
         <Nullable>enable</Nullable>
         <AssemblyName>KaWoDev.BitwardenJsonConverter.BitwardenConverter.Contract</AssemblyName>
         <RootNamespace>KaWoDev.BitwardenJsonConverter.BitwardenConverter.Contract</RootNamespace>
-        <PackageId>KaWoDev.BitwardenJsonConverter.</PackageId>
         <Authors>KaWoDev &amp; Github Contributers</Authors>
         <PackageProjectUrl>https://github.com/kawodev/bitwardenJsonConverter</PackageProjectUrl>
         <PackageLicenseUrl>https://github.com/kawodev/bitwardenJsonConverter/License</PackageLicenseUrl>

--- a/BitwardenJsonConverter/Source/BitwardenConverter/BitwardenConverter.csproj
+++ b/BitwardenJsonConverter/Source/BitwardenConverter/BitwardenConverter.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <AssemblyName>KaWoDev.BitwardenJsonConverter.BitwardenConverter</AssemblyName>
     <RootNamespace>KaWoDev.BitwardenJsonConverter.BitwardenConverter</RootNamespace>
-    <PackageId>KaWoDev.BitwardenJsonConverter.</PackageId>
     <Authors>KaWoDev &amp; Github Contributers</Authors>
     <PackageProjectUrl>https://github.com/kawodev/bitwardenJsonConverter</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/kawodev/bitwardenJsonConverter/License</PackageLicenseUrl>


### PR DESCRIPTION
The reason from the cycle detection at the build process is the same package id in multiple csproj files.